### PR TITLE
Fix: Grant permissions to Hacktoberfest label workflow

### DIFF
--- a/.github/workflows/hacktoberfest-label.yml
+++ b/.github/workflows/hacktoberfest-label.yml
@@ -13,6 +13,8 @@ jobs:
   addLabel:
     name: Hacktoberfest Label
     runs-on: ubuntu-latest
+    permissions:
+      issues: write 
     steps:
       - name: Check if it's October
         id: check_month


### PR DESCRIPTION
This pull request resolves issue #10.

The Hacktoberfest labeling workflow was failing with a permissions error (`HttpError: Resource not accessible by integration`) .

This change adds the `issues: write` permission to the `hacktoberfest-label.yml` file, allowing the action to successfully add labels to new pull requests.

Closes #10