### PR TITLE
feat(users): add user table schema for profiles and auth (#15)

### DIFF
--- a/.github/workflows/hacktoberfest-label.yml
+++ b/.github/workflows/hacktoberfest-label.yml
@@ -6,6 +6,7 @@ on:
       - opened
 
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 

--- a/migrations/20251002000100_add_users_and_sessions.down.sql
+++ b/migrations/20251002000100_add_users_and_sessions.down.sql
@@ -1,0 +1,39 @@
+-- Down migration for adding users and sessions
+
+-- Drop indexes
+DROP INDEX IF EXISTS idx_urls_owner_id;
+DROP INDEX IF EXISTS idx_sessions_expires_at;
+DROP INDEX IF EXISTS idx_sessions_user_id;
+DROP INDEX IF EXISTS idx_users_email;
+
+-- Remove owner_id column from urls
+-- SQLite does not support DROP COLUMN directly; need table rebuild.
+-- We'll perform a safe table recreation to drop the column if it exists.
+
+PRAGMA foreign_keys=off;
+
+BEGIN TRANSACTION;
+
+-- Create a temporary table without owner_id
+CREATE TABLE IF NOT EXISTS urls_tmp (
+    id TEXT PRIMARY KEY,
+    url TEXT NOT NULL
+);
+
+-- Copy data back (ignore owner_id)
+INSERT INTO urls_tmp (id, url)
+SELECT id, url FROM urls;
+
+-- Replace old table
+DROP TABLE urls;
+ALTER TABLE urls_tmp RENAME TO urls;
+
+COMMIT;
+
+PRAGMA foreign_keys=on;
+
+-- Drop sessions and users tables
+DROP TABLE IF EXISTS sessions;
+DROP TABLE IF EXISTS users;
+
+

--- a/migrations/20251002000100_add_users_and_sessions.up.sql
+++ b/migrations/20251002000100_add_users_and_sessions.up.sql
@@ -1,0 +1,41 @@
+-- Create users table
+CREATE TABLE IF NOT EXISTS users (
+    id            TEXT PRIMARY KEY,             -- uuid (string) for portability
+    email         TEXT NOT NULL UNIQUE,         -- unique email
+    password_hash TEXT NOT NULL,                -- argon2/scrypt/bcrypt hash
+    created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Basic index to speed up lookups by email
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+-- Create sessions table for session-based auth (future expansion)
+CREATE TABLE IF NOT EXISTS sessions (
+    id             TEXT PRIMARY KEY,            -- session id (uuid or random)
+    user_id        TEXT NOT NULL,               -- FK to users.id
+    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at     DATETIME NOT NULL,           -- absolute expiry
+    last_active_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    user_agent     TEXT,                        -- optional metadata
+    ip_address     TEXT,                        -- optional metadata
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Useful indexes for sessions
+CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
+
+-- Add owner_id column to urls to support per-user ownership
+ALTER TABLE urls ADD COLUMN owner_id TEXT NULL;
+
+-- Optional: create index for owner_id to list a user's URLs quickly
+CREATE INDEX IF NOT EXISTS idx_urls_owner_id ON urls(owner_id);
+
+-- Note: We do not add a strict FK on urls.owner_id yet to keep backward
+-- compatibility with existing rows (NULL allowed). Once all rows are owned,
+-- you can migrate data and enforce FK if desired:
+-- ALTER TABLE urls ADD CONSTRAINT fk_urls_owner
+--   FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE SET NULL;
+
+


### PR DESCRIPTION
### Description
Add database support for user profiles and session-based auth. Introduces `users` and `sessions` tables and associates shortened URLs with an optional `owner_id` on `urls` for per-user ownership. Includes indexes for common lookups and a reversible down migration (rebuilds `urls` to drop `owner_id` in SQLite).

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe)

### Testing
- [ ] Tests pass locally
- [ ] New tests added for new functionality
- [ ] Manual testing completed

Notes:
- Migrations are applied automatically on startup via existing migration mechanism.
- No application-layer auth logic added yet; schema-only change.

### Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Code is commented where necessary
- [ ] Documentation updated
- [ ] No merge conflicts

Additional notes:
- `owner_id` on `urls` is nullable for backward compatibility; consider backfilling and enforcing FK later.
- Indexes: `users(email)`, `sessions(user_id)`, `sessions(expires_at)`, `urls(owner_id)`.

