### PR TITLE
refactor(api): standardize API design and replace non-standard notion (#4)

### DIFF
--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -48,6 +48,7 @@ pub mod admin;
 // Module declarations
 pub mod health_check;
 pub mod index;
+pub mod realworld;
 pub mod redirect;
 pub mod shorten;
 
@@ -56,5 +57,6 @@ pub use admin::*;
 // Re-exports for convenience
 pub use health_check::*;
 pub use index::*;
+pub use realworld::*;
 pub use redirect::*;
 pub use shorten::*;

--- a/src/routes/realworld.rs
+++ b/src/routes/realworld.rs
@@ -1,0 +1,130 @@
+//! RealWorld API minimal scaffold
+//!
+//! Implements a minimal subset of the RealWorld spec endpoints to integrate
+//! alongside the existing URL shortener API. These handlers return the exact
+//! response shapes required by the RealWorld spec (no custom envelope).
+//!
+//! Endpoints:
+//! - `GET /api/tags`
+//! - `POST /api/users` (register)
+//! - `POST /api/users/login`
+//! - `GET /api/user` (current user)
+
+use crate::state::AppState;
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize)]
+struct TagsResponse {
+    tags: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
+    user: RegisterUser,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct RegisterUser {
+    email: String,
+    password: String,
+    username: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LoginRequest {
+    user: LoginUser,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct LoginUser {
+    email: String,
+    password: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UserEnvelope {
+    user: UserResponse,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UserResponse {
+    email: String,
+    token: String,
+    username: String,
+    bio: Option<String>,
+    image: Option<String>,
+}
+
+/// GET /api/tags
+pub async fn get_tags(_state: State<AppState>) -> impl IntoResponse {
+    let resp = TagsResponse {
+        tags: vec![
+            "rust".to_string(),
+            "axum".to_string(),
+            "realworld".to_string(),
+        ],
+    };
+    (StatusCode::OK, Json(resp))
+}
+
+/// POST /api/users (register)
+pub async fn post_users_register(
+    _state: State<AppState>,
+    Json(payload): Json<RegisterRequest>,
+) -> impl IntoResponse {
+    // Stubbed token and echo back provided fields to satisfy RealWorld shape
+    let user = UserEnvelope {
+        user: UserResponse {
+            email: payload.user.email,
+            username: payload.user.username,
+            token: "stub.jwt.token".to_string(),
+            bio: None,
+            image: None,
+        },
+    };
+    (StatusCode::CREATED, Json(user))
+}
+
+/// POST /api/users/login
+pub async fn post_users_login(
+    _state: State<AppState>,
+    Json(payload): Json<LoginRequest>,
+) -> impl IntoResponse {
+    // Stubbed user; in future, validate credentials and issue JWT
+    let username_from_email = payload
+        .user
+        .email
+        .split('@')
+        .next()
+        .unwrap_or("user")
+        .to_string();
+
+    let user = UserEnvelope {
+        user: UserResponse {
+            email: payload.user.email,
+            username: username_from_email,
+            token: "stub.jwt.token".to_string(),
+            bio: None,
+            image: None,
+        },
+    };
+    (StatusCode::OK, Json(user))
+}
+
+/// GET /api/user
+pub async fn get_current_user(_state: State<AppState>) -> impl IntoResponse {
+    // Stub current user until auth is implemented
+    let user = UserEnvelope {
+        user: UserResponse {
+            email: "demo@example.com".to_string(),
+            username: "demo".to_string(),
+            token: "stub.jwt.token".to_string(),
+            bio: None,
+            image: None,
+        },
+    };
+    (StatusCode::OK, Json(user))
+}

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -53,8 +53,8 @@ use crate::database::postgres_sql::PostgresUrlDatabase;
 use crate::database::{SqliteUrlDatabase, UrlDatabase};
 use crate::middleware::check_api_key;
 use crate::routes::{
-    get_admin_dashboard, get_index, get_login, get_redirect, get_register, get_user_profile,
-    health_check, post_shorten,
+    get_admin_dashboard, get_current_user, get_index, get_login, get_redirect, get_register,
+    get_tags, get_user_profile, health_check, post_shorten, post_users_login, post_users_register,
 };
 use crate::state::AppState;
 use crate::telemetry::MakeRequestUuid;
@@ -444,12 +444,20 @@ pub async fn build_router(state: AppState) -> Result<Router, anyhow::Error> {
         .route("/admin/register", get(get_register))
         .route_layer(from_fn_with_state(state.clone(), check_api_key));
 
+    // RealWorld API routes (public for now; auth to be added later)
+    let realworld_routes = Router::new()
+        .route("/api/tags", get(get_tags))
+        .route("/api/users", post(post_users_register))
+        .route("/api/users/login", post(post_users_login))
+        .route("/api/user", get(get_current_user));
+
     // Merge all routes together
     let router = Router::new()
         .merge(public_routes)
         .merge(public_shorten)
         .merge(protected_api)
         .merge(protected_admin)
+        .merge(realworld_routes)
         .fallback_service(ServeDir::new("static"))
         .with_state(state)
         .layer(


### PR DESCRIPTION
## Description
Implemented RealWorld API specification endpoints alongside existing URL shortener functionality. Added minimal stub implementations for user authentication and tags endpoints that follow the RealWorld spec response format.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe)

## Testing
- [x] Tests pass locally
- [ ] New tests added for new functionality
- [x] Manual testing completed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated
- [x] No merge conflicts

## Details

### Changes Made
- **New RealWorld API module** (`src/routes/realworld.rs`):
  - `GET /api/tags` - Returns list of tags
  - `POST /api/users` - User registration (stub)
  - `POST /api/users/login` - User login (stub) 
  - `GET /api/user` - Current user info (stub)

- **Router integration** (`src/startup.rs`):
  - Added RealWorld routes to main router
  - Routes are public (no auth middleware) for initial implementation

- **Module exports** (`src/routes/mod.rs`):
  - Added realworld module and re-exports

### Response Format
- RealWorld endpoints return spec-compliant JSON responses (not the project's custom `ApiResponse` envelope)
- User responses include: `{ "user": { "email", "token", "username", "bio", "image" } }`
- Tags response: `{ "tags": [...] }`

### Future Work
- Implement actual JWT authentication
- Add user persistence to database
- Add password hashing and validation
- Add proper error handling for auth failures
- Add tests for RealWorld endpoints

### Notes
- All endpoints are currently stub implementations that return mock data
- Code formatting has been applied (`cargo fmt`)
- Dead code warnings suppressed for unused password fields (part of RealWorld spec)