### PR TITLE
✨ feat(api)!: implement `ApiResponse` for `shorten` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A high-performance URL shortener service built with modern Rust technologies. Th
 ## 📡 API Endpoints
 
 ### Shorten a URL
+
 ```bash
 POST /api/shorten
 Content-Type: text/plain
@@ -42,12 +43,24 @@ curl -d 'https://www.google.com/' \
   http://localhost:8000/api/shorten
 ```
 
-**Response**: Returns the shortened URL
-```
-https://localhost:8000/AbC123
+**Response**: Returns a JSON response with shortened URL information
+
+```json
+{
+  "success": true,
+  "message": "ok",
+  "status": 200,
+  "time": "2025-10-05T12:00:00Z",
+  "data": {
+    "shortened_url": "https://localhost:8000/AbC123",
+    "original_url": "https://www.google.com/",
+    "id": "AbC123"
+  }
+}
 ```
 
 ### Redirect to Original URL
+
 ```bash
 GET /api/redirect/{id}
 
@@ -58,6 +71,7 @@ curl -L http://localhost:8000/api/redirect/AbC123
 **Response**: HTTP 308 Permanent Redirect to the original URL
 
 ### Health Check
+
 ```bash
 GET /api/health_check
 
@@ -66,6 +80,7 @@ curl http://localhost:8000/api/health_check
 ```
 
 **Response**: HTTP 200 OK with JSON envelope
+
 ```json
 {
   "success": true,
@@ -77,6 +92,7 @@ curl http://localhost:8000/api/health_check
 ```
 
 ### Admin Interface
+
 ```bash
 GET /admin
 
@@ -89,6 +105,7 @@ curl http://localhost:8000/admin
 ## 🚀 Quick Start
 
 ### Prerequisites
+
 - [Rust](https://rustup.rs/) (latest stable)
 - [SQLx CLI](https://crates.io/crates/sqlx-cli)
 - Database: SQLite (no setup required) or PostgreSQL (optional)
@@ -99,22 +116,26 @@ curl http://localhost:8000/admin
 #### Option 1: Traditional Rust Development
 
 1. **Clone the repository**
+
    ```bash
    git clone https://github.com/yourusername/url-shortener-ztm.git
    cd url-shortener-ztm
    ```
 
 2. **Install dependencies**
+
    ```bash
    cargo build
    ```
 
 3. **Create the Database**
+
    ```bash
    sqlx database create
    ```
 
 4. **Run the application**
+
    ```bash
    cargo run
    ```
@@ -124,12 +145,14 @@ curl http://localhost:8000/admin
 #### Option 2: Nix Development Environment
 
 1. **Clone the repository**
+
    ```bash
    git clone https://github.com/yourusername/url-shortener-ztm.git
    cd url-shortener-ztm
    ```
 
 2. **Enter the Nix development environment**
+
    ```bash
    nix develop
    ```
@@ -137,26 +160,28 @@ curl http://localhost:8000/admin
    This provides a complete development environment with Rust toolchain, SQLx CLI, and all dependencies.
 
 3. **Run the application**
+
    ```bash
    cargo run
    ```
 
 4. **Test the service**
+
    ```bash
    # Get your API key from configuration/base.yaml (or set via environment)
    API_KEY="e4125dd1-3d3e-43a1-bc9c-dc0ba12ad4b5"
-   
+
    # Shorten a URL
    curl -d 'https://example.com' \
      -H "x-api-key: $API_KEY" \
      http://localhost:8000/api/shorten
-   
+
    # Visit the shortened URL
    curl -L http://localhost:8000/api/redirect/AbC123
-   
+
    # Check health
    curl http://localhost:8000/api/health_check
-   
+
    # Visit admin interface
    open http://localhost:8000/admin
    ```
@@ -166,14 +191,17 @@ curl http://localhost:8000/admin
 The application supports environment-based configuration with YAML files:
 
 #### Configuration Files
+
 - `configuration/base.yaml` - Base configuration
 - `configuration/local.yaml` - Local development overrides
 - `configuration/production.yaml` - Production settings
 
 #### Environment Variables
+
 Set `APP_ENVIRONMENT` to `local` or `production` to load the appropriate config.
 
 Override any setting using environment variables with `APP_` prefix:
+
 ```bash
 APP_APPLICATION__PORT=3000
 APP_APPLICATION__API_KEY=your-new-api-key
@@ -183,13 +211,15 @@ APP_DATABASE__DATABASE_PATH=./my-database.db
 #### Database Configuration
 
 **SQLite Configuration (Default)**
+
 ```yaml
 database:
-  database_path: "sqlite:database.db"  # Path to SQLite database file
-  create_if_missing: true              # Create database if it doesn't exist
+  database_path: "sqlite:database.db" # Path to SQLite database file
+  create_if_missing: true # Create database if it doesn't exist
 ```
 
 **PostgreSQL Configuration**
+
 ```yaml
 database:
   host: "localhost"
@@ -201,6 +231,7 @@ database:
 ```
 
 **For in-memory database (testing):**
+
 ```yaml
 database:
   database_path: ":memory:"
@@ -208,34 +239,38 @@ database:
 ```
 
 #### Rate Limiting Configuration
+
 The service includes built-in rate limiting to prevent abuse using the [tower-governor](https://crates.io/crates/tower_governor) crate:
 
 ```yaml
 rate_limiting:
-  enabled: true              # Enable/disable rate limiting
-  requests_per_second: 10    # Maximum sustained request rate per IP
-  burst_size: 5              # Additional burst capacity per IP
+  enabled: true # Enable/disable rate limiting
+  requests_per_second: 10 # Maximum sustained request rate per IP
+  burst_size: 5 # Additional burst capacity per IP
 ```
 
 **Environment-specific examples:**
 
 **Development** (`configuration/local.yaml`):
+
 ```yaml
 rate_limiting:
   enabled: true
-  requests_per_second: 20    # More lenient for development
+  requests_per_second: 20 # More lenient for development
   burst_size: 10
 ```
 
 **Production** (`configuration/production.yaml`):
+
 ```yaml
 rate_limiting:
   enabled: true
-  requests_per_second: 5     # Strict rate limiting for production
+  requests_per_second: 5 # Strict rate limiting for production
   burst_size: 3
 ```
 
 **Rate Limiting Behavior:**
+
 - Limits are applied **per IP address** using the GCRA (Generic Cell Rate Algorithm)
 - Only **URL shortening endpoints** are rate limited (`/api/shorten`, `/api/public/shorten`)
 - Health checks and redirects are **not rate limited**
@@ -245,6 +280,7 @@ rate_limiting:
 - Returns **HTTP 429 Too Many Requests** when limits are exceeded
 
 **Environment Variable Override:**
+
 ```bash
 APP_RATE_LIMITING__ENABLED=false                 # Disable rate limiting
 APP_RATE_LIMITING__REQUESTS_PER_SECOND=100       # 100 requests per second
@@ -272,6 +308,7 @@ cargo test postgres_database_insert_get -- --ignored
 ```
 
 ### Test Coverage
+
 - ✅ Health check endpoint with JSON envelope validation
 - ✅ URL shortening functionality with API key authentication
 - ✅ URL redirection with proper HTTP status codes
@@ -347,6 +384,7 @@ flake.nix                          # Nix development environment
 ## 🔧 Architecture
 
 ### Database Layer
+
 The application uses a trait-based database abstraction (`UrlDatabase`) that supports both SQLite and PostgreSQL:
 
 ```rust
@@ -358,6 +396,7 @@ pub trait UrlDatabase: Send + Sync {
 ```
 
 ### Error Handling
+
 Comprehensive error handling with custom `ApiError` types and structured JSON responses:
 
 ```rust
@@ -371,6 +410,7 @@ pub enum ApiError {
 ```
 
 ### Configuration Management
+
 Layered configuration system supporting YAML files and environment variables with automatic environment detection.
 
 ## 📊 Database Schema
@@ -428,6 +468,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 5. Open a Pull Request
 
 ### Development Guidelines
+
 - Ensure all tests pass (`cargo test`)
 - Follow Rust naming conventions
 - Add tests for new functionality
@@ -440,6 +481,7 @@ This project is licensed under the MIT License - see the [License.txt](License.t
 ## 👤 Author
 
 **Jeffery D. Mitchell**
+
 - Email: crusty.rustacean@gmail.com
 - GitHub: [@crustyrustacean](https://github.com/crustyrustacean)
 

--- a/static/scripts.js
+++ b/static/scripts.js
@@ -11,51 +11,51 @@ if (yearEl) {
 class UrlShortener {
   constructor() {
     // Wait for DOM to be ready
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', () => this.init());
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", () => this.init());
     } else {
       this.init();
     }
   }
 
   init() {
-    this.form = document.getElementById('urlForm');
-    this.urlInput = document.getElementById('urlInput');
-    this.submitBtn = document.getElementById('submitBtn');
-    this.result = document.getElementById('result');
-    this.error = document.getElementById('error');
-    this.shortUrl = document.getElementById('shortUrl');
-    this.originalUrl = document.getElementById('originalUrl');
-    this.copyBtn = document.getElementById('copyBtn');
-    this.retryBtn = document.getElementById('retryBtn');
-    
+    this.form = document.getElementById("urlForm");
+    this.urlInput = document.getElementById("urlInput");
+    this.submitBtn = document.getElementById("submitBtn");
+    this.result = document.getElementById("result");
+    this.error = document.getElementById("error");
+    this.shortUrl = document.getElementById("shortUrl");
+    this.originalUrl = document.getElementById("originalUrl");
+    this.copyBtn = document.getElementById("copyBtn");
+    this.retryBtn = document.getElementById("retryBtn");
+
     if (!this.form || !this.urlInput || !this.submitBtn) {
-      console.error('Required form elements not found!');
+      console.error("Required form elements not found!");
       return;
     }
 
-    this.btnText = this.submitBtn.querySelector('.btn-text');
-    this.btnLoading = this.submitBtn.querySelector('.btn-loading');
-    this.copyText = this.copyBtn?.querySelector('.copy-text');
-    this.copySuccess = this.copyBtn?.querySelector('.copy-success');
-    
+    this.btnText = this.submitBtn.querySelector(".btn-text");
+    this.btnLoading = this.submitBtn.querySelector(".btn-loading");
+    this.copyText = this.copyBtn?.querySelector(".copy-text");
+    this.copySuccess = this.copyBtn?.querySelector(".copy-success");
+
     // Add event listeners
-    this.form.addEventListener('submit', (e) => this.handleSubmit(e));
-    
+    this.form.addEventListener("submit", (e) => this.handleSubmit(e));
+
     if (this.copyBtn) {
-      this.copyBtn.addEventListener('click', () => this.copyToClipboard());
+      this.copyBtn.addEventListener("click", () => this.copyToClipboard());
     }
-    
+
     if (this.retryBtn) {
-      this.retryBtn.addEventListener('click', () => this.clearResults());
+      this.retryBtn.addEventListener("click", () => this.clearResults());
     }
-    
-    this.urlInput.addEventListener('input', () => this.clearResults());
+
+    this.urlInput.addEventListener("input", () => this.clearResults());
   }
 
   async handleSubmit(e) {
     e.preventDefault();
-    
+
     const url = this.urlInput.value.trim();
     if (!url) return;
 
@@ -63,24 +63,41 @@ class UrlShortener {
     this.clearResults();
 
     try {
-      const response = await fetch('/api/shorten', {
-        method: 'POST',
+      const response = await fetch("/api/shorten", {
+        method: "POST",
         headers: {
-          'Content-Type': 'text/plain',
-          'X-API-Key': 'e4125dd1-3d3e-43a1-bc9c-dc0ba12ad4b5'
+          "Content-Type": "text/plain",
+          "X-API-Key": "e4125dd1-3d3e-43a1-bc9c-dc0ba12ad4b5",
         },
-        body: url
+        body: url,
       });
 
       if (response.ok) {
-        const shortUrl = await response.text();
-        this.showResult(url, shortUrl.trim());
+        const jsonResponse = await response.json();
+        if (jsonResponse.success && jsonResponse.data) {
+          this.showResult(
+            jsonResponse.data.original_url,
+            jsonResponse.data.shortened_url
+          );
+        } else {
+          this.showError(
+            `Failed to shorten URL: ${jsonResponse.message || "Unknown error"}`
+          );
+        }
       } else {
-        const errorText = await response.text();
-        this.showError(`Failed to shorten URL: ${errorText}`);
+        // Try to parse JSON error response
+        try {
+          const errorResponse = await response.json();
+          const errorMessage =
+            errorResponse.message || "Unknown error occurred";
+          this.showError(`Failed to shorten URL: ${errorMessage}`);
+        } catch {
+          const errorText = await response.text();
+          this.showError(`Failed to shorten URL: ${errorText}`);
+        }
       }
     } catch (err) {
-      console.error('Network error:', err);
+      console.error("Network error:", err);
       this.showError(`Network error: ${err.message}`);
     } finally {
       this.setLoading(false);
@@ -90,35 +107,35 @@ class UrlShortener {
   setLoading(loading) {
     this.submitBtn.disabled = loading;
     if (loading) {
-      this.btnText.style.display = 'none';
-      this.btnLoading.style.display = 'flex';
+      this.btnText.style.display = "none";
+      this.btnLoading.style.display = "flex";
     } else {
-      this.btnText.style.display = 'inline';
-      this.btnLoading.style.display = 'none';
+      this.btnText.style.display = "inline";
+      this.btnLoading.style.display = "none";
     }
   }
 
   showResult(originalUrl, shortUrl) {
     this.shortUrl.value = shortUrl;
     this.originalUrl.textContent = originalUrl;
-    this.result.style.display = 'block';
-    
+    this.result.style.display = "block";
+
     // Scroll to result
-    this.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    this.result.scrollIntoView({ behavior: "smooth", block: "nearest" });
   }
 
   showError(message) {
-    const errorMessage = document.getElementById('errorMessage');
+    const errorMessage = document.getElementById("errorMessage");
     errorMessage.textContent = message;
-    this.error.style.display = 'block';
-    
+    this.error.style.display = "block";
+
     // Scroll to error
-    this.error.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    this.error.scrollIntoView({ behavior: "smooth", block: "nearest" });
   }
 
   clearResults() {
-    this.result.style.display = 'none';
-    this.error.style.display = 'none';
+    this.result.style.display = "none";
+    this.error.style.display = "none";
   }
 
   async copyToClipboard() {
@@ -128,18 +145,18 @@ class UrlShortener {
     } catch (err) {
       // Fallback for older browsers
       this.shortUrl.select();
-      document.execCommand('copy');
+      document.execCommand("copy");
       this.showCopySuccess();
     }
   }
 
   showCopySuccess() {
-    this.copyText.style.display = 'none';
-    this.copySuccess.style.display = 'inline';
-    
+    this.copyText.style.display = "none";
+    this.copySuccess.style.display = "inline";
+
     setTimeout(() => {
-      this.copyText.style.display = 'inline';
-      this.copySuccess.style.display = 'none';
+      this.copyText.style.display = "inline";
+      this.copySuccess.style.display = "none";
     }, 2000);
   }
 }


### PR DESCRIPTION
## Summary

BREAKING CHANGE: `shorten` endpoint now returns JSON instead of plain text

- Add `ShortenResponse` struct with `shortened_url`, `original_url`, and `id`
- Update frontend JS to handle JSON response format
- Provides consistent API response structure across all endpoints

Closes #1
**ref: #1**