### PR TITLE
Fix: Replace hardcoded localhost with dynamic host from header

### DIFF
--- a/src/routes/shorten.rs
+++ b/src/routes/shorten.rs
@@ -122,7 +122,7 @@ pub async fn post_shorten(
         tracing::error!("Unable to parse URL");
         ApiError::Unprocessable(e.to_string())
     })?;
-    let host = "localhost";
+    let host = header.hostname();
 
     match state.database.insert_url(id, p_url.as_str()).await {
         Ok(()) => {

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -147,19 +147,20 @@ impl TestApp {
     }
 
     // Authenticated POST with API key header
-    pub async fn post_api_with_key(
-        &self,
-        path: &str,
-        body: impl Into<String>,
-    ) -> reqwest::Response {
-        self.client
-            .post(self.api(path))
-            .header("x-api-key", self.api_key.to_string())
-            .body(body.into())
-            .send()
-            .await
-            .expect("Failed to execute POST request")
-    }
+     pub async fn post_api_with_key(
+    &self,
+    path: &str,
+    body: impl Into<String>,
+) -> reqwest::Response {
+    self.client
+        .post(self.api(path))
+        .header("x-api-key", self.api_key.to_string())
+        .header("host", "localhost:8000")  // ← Add this line
+        .body(body.into())
+        .send()
+        .await
+        .expect("Failed to execute POST request")
+}
 
     // Admin route helpers
     pub async fn get_admin_dashboard(&self) -> reqwest::Response {

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -147,20 +147,20 @@ impl TestApp {
     }
 
     // Authenticated POST with API key header
-     pub async fn post_api_with_key(
-    &self,
-    path: &str,
-    body: impl Into<String>,
-) -> reqwest::Response {
-    self.client
-        .post(self.api(path))
-        .header("x-api-key", self.api_key.to_string())
-        .header("host", "localhost:8000")  // ← Add this line
-        .body(body.into())
-        .send()
-        .await
-        .expect("Failed to execute POST request")
-}
+    pub async fn post_api_with_key(
+        &self,
+        path: &str,
+        body: impl Into<String>,
+    ) -> reqwest::Response {
+        self.client
+            .post(self.api(path))
+            .header("x-api-key", self.api_key.to_string())
+            .header("host", "localhost:8000") // ← Add this line
+            .body(body.into())
+            .send()
+            .await
+            .expect("Failed to execute POST request")
+    }
 
     // Admin route helpers
     pub async fn get_admin_dashboard(&self) -> reqwest::Response {


### PR DESCRIPTION
- Changed src/routes/shorten.rs to use header.hostname()
- Updated tests/api/helpers.rs to include Host header
- Modified post_api_with_key() to send host header

Resolves #24
## 🐛 Bug Fix

Fixes #24

## Changes Made

- Modified `src/routes/shorten.rs` line 101 to use `header.hostname()` instead of hardcoded `"localhost"`
- Updated `tests/api/helpers.rs` to include Host header in test requests (lines 150, 164)

## Implementation

The `TypedHeader<Host>` was already being extracted but not utilized. This fix uses `header.hostname()` to get the actual hostname from requests.

**Before:**
```rust
let host = "localhost";