### PR TITLE
✨ feat(redirect): validate short link IDs before database lookup

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -34,6 +34,7 @@ use crate::configuration::Settings;
 use crate::database::UrlDatabase;
 use crate::generator::ShortCodeGenerator;
 use axum_macros::FromRef;
+use std::collections::HashSet;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -83,9 +84,11 @@ use uuid::Uuid;
 pub struct AppState {
     /// Database connection for URL storage and retrieval operations
     pub database: Arc<dyn UrlDatabase>,
-
+    /// Short code generator for creating unique short URLs
     pub code_generator: Arc<dyn ShortCodeGenerator>,
-
+    /// The set of characters that can be used when generating short codes. \
+    /// Typically includes alphanumeric characters (e.g., `a-z`, `A-Z`, `0-9`).
+    pub allowed_chars: HashSet<char>,
     /// UUID-based API key for authenticating protected endpoints
     pub api_key: Uuid,
     /// Directory path containing Tera template files for web interface
@@ -138,6 +141,7 @@ impl AppState {
     pub fn new(
         database: Arc<dyn UrlDatabase>,
         code_generator: Arc<dyn ShortCodeGenerator>,
+        allowed_chars: HashSet<char>,
         api_key: Uuid,
         template_dir: String,
         config: Settings,
@@ -145,6 +149,7 @@ impl AppState {
         Self {
             database,
             api_key,
+            allowed_chars,
             template_dir,
             config,
             code_generator,

--- a/tests/api/redirect.rs
+++ b/tests/api/redirect.rs
@@ -13,7 +13,7 @@ async fn redirect_endpoint_sends_user_to_shortened_destination_url() {
     let app = spawn_app().await;
 
     // Insert a test URL into the database
-    let test_id = "tst123";
+    let test_id = "tstA123";
     let test_url = "https://www.google.com";
 
     // Insert the test data into the database
@@ -27,4 +27,46 @@ async fn redirect_endpoint_sends_user_to_shortened_destination_url() {
 
     // Assert
     assert_redirect_to(response, test_url, StatusCode::PERMANENT_REDIRECT).await;
+}
+
+#[tokio::test]
+async fn redirect_rejects_invalid_characters() {
+    let app = spawn_app().await;
+
+    let invalid_id = "tst$12";
+
+    let response = app.get_api(&format!("/api/redirect/{}", invalid_id)).await;
+
+    assert_eq!(response.status().as_u16(), 404);
+}
+
+#[tokio::test]
+async fn redirect_rejects_invalid_length() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Read configured shortener length
+    let config = url_shortener_ztm_lib::get_configuration().expect("Failed to read configuration");
+    let len = config.shortener.length;
+
+    // Build ids that are one shorter and one longer than configured length.
+    // Use 'a' which is within allowed alphabet.
+    let shorter = "a".repeat(len.saturating_sub(1));
+    let longer = "a".repeat(len + 1);
+
+    // Act
+    let resp_short = app.get_api(&format!("/api/redirect/{}", shorter)).await;
+    let resp_long = app.get_api(&format!("/api/redirect/{}", longer)).await;
+
+    // Assert - both should be rejected as Not Found (handler validates length before DB lookup)
+    assert_eq!(
+        resp_short.status().as_u16(),
+        404,
+        "Expected 404 for id with length -1"
+    );
+    assert_eq!(
+        resp_long.status().as_u16(),
+        404,
+        "Expected 404 for id with length +1"
+    );
 }


### PR DESCRIPTION
- Added pre-validation for short link IDs to reject invalid lengths or characters.
- Added new route `/ {id}` for direct redirect access.
- Introduced allowed_chars in AppState for centralized validation logic.
- Added tests for invalid length and characters.

- #35