### PR TITLE
test(static): assert served assets match file content exactly

### DIFF
--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -6,3 +6,4 @@ mod helpers;
 mod rate_limiting;
 mod redirect;
 mod shorten;
+mod static_assets;

--- a/tests/api/static_assets.rs
+++ b/tests/api/static_assets.rs
@@ -1,0 +1,56 @@
+use crate::helpers::{TestApp, spawn_app};
+
+use std::fs;
+
+async fn assert_asset_ok(app: &TestApp, path: &str, expected_content_type: &str, file_path: &str) {
+    let resp = app.get(path).await;
+    assert!(resp.status().is_success(), "{} not served", path);
+    let ct = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        ct.contains(expected_content_type),
+        "{} has wrong content-type: {}",
+        path,
+        ct
+    );
+    let body = resp.text().await.expect("Failed to read asset body");
+    let expected = fs::read_to_string(file_path).expect("Failed to read asset file");
+    assert_eq!(body, expected, "{} does not match file content", path);
+}
+
+#[tokio::test]
+async fn assets_are_served() {
+    let app = spawn_app().await;
+
+    // Check HTML index page
+    let index_resp = app.get("/").await;
+    assert!(index_resp.status().is_success(), "Index page not served");
+    let index_body = index_resp.text().await.expect("Failed to read index body");
+    assert!(
+        index_body.contains("<title>URL Shortener | Home</title>"),
+        "Index page missing expected <title>"
+    );
+    assert!(
+        index_body.contains("/static/screen.css"),
+        "Index page missing CSS link"
+    );
+    assert!(
+        index_body.contains("/static/scripts.js"),
+        "Index page missing JS script"
+    );
+
+    // Check CSS asset
+    assert_asset_ok(&app, "/static/screen.css", "css", "static/screen.css").await;
+
+    // Check JS asset
+    assert_asset_ok(
+        &app,
+        "/static/scripts.js",
+        "javascript",
+        "static/scripts.js",
+    )
+    .await;
+}


### PR DESCRIPTION
## Summary

This pull request introduces new tests to ensure that static assets (HTML, CSS, and JavaScript) are properly served by the application. The main addition is a new test module that verifies both the presence and correctness of these assets in HTTP responses.

**New static asset tests:**

* Added a new test module `static_assets` to the test helpers (`tests/api/main.rs`).
* Implemented `assets_are_served` test in `tests/api/static_assets.rs` to verify that the index page, CSS, and JavaScript assets are served with the correct content and content-type headers.
* Added a helper function `assert_asset_ok` to check asset serving and validate content against the corresponding static files.

> This addresses issue #16 and #44 and ensures that any future changes to routing or asset handling will be caught by CI, improving reliability for users and maintainers.

Fixes #16