### PR TITLE
🐞 fix(bloom): prevent test failures from concurrent snapshot writes

### DIFF
--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -41,6 +41,7 @@ pub struct TestApp {
 pub async fn spawn_app() -> TestApp {
     // Ensure that the tracing is only initialized once
     LazyLock::force(&TRACING);
+    unsafe { std::env::set_var("BLOOM_SNAPSHOTS", "1") };
 
     // Randomise configuration to ensure test isolation
     let configuration = {


### PR DESCRIPTION
- Disable Bloom snapshot saving in tests via BLOOM_SNAPSHOTS=1
- Prevents race conditions during parallel test runs