### PR TITLE
docs: Initial OpenAPI spec for /shorten endpoint (#59)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,44 @@
+# openapi.yaml
+openapi: 3.0.0
+info:
+  title: URL Shortener API
+  version: 1.0.0
+  description: API for shortening URLs.
+servers:
+  - url: /
+    description: Local development server
+paths:
+  /shorten:
+    post:
+      summary: Creates a new shortened URL
+      description: Submits a long URL to the service and receives a unique short key.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+                  format: url
+                  description: The original long URL to be shortened.
+              required:
+                - url
+      responses:
+        '201':
+          description: Short URL created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  short_key:
+                    type: string
+                    description: The unique key for the shortened URL.
+                  short_url:
+                    type: string
+                    format: url
+                    description: The full shortened URL.
+        '400':
+          description: Invalid URL provided


### PR DESCRIPTION
Addresses Issue #59. This PR introduces the initial openapi.yaml file, documenting the core /shorten POST endpoint using OpenAPI 3.0 specifications. This is a partial solution to begin the API documentation effort(Addresses #59).