### PR TITLE
🧪 build(perf): add performance test suite and data generation tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ NUL
 
 # Shuttle
 .shuttle
+reports

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,12 @@
           openssl
           sqlx-cli
           sqlite
+          oha
+          nushell
+          postgresql
+          hey
+          just
+          k6
         ];
 
         # Convert ymal to JSON for environment preparation

--- a/justfile
+++ b/justfile
@@ -1,0 +1,92 @@
+# 🌿 Use Nushell as the shell
+set shell := ["nu", "-c"]
+
+shebang := if os() == 'windows' {
+	'nu.exe'
+} else {
+	'/usr/bin/env nu'
+}
+
+# ── 🧰 Base config (can be overridden in .env) ─────────────────────
+BASE := "http://127.0.0.1:8000"
+API_KEY := "e4125dd1-3d3e-43a1-bc9c-dc0ba12ad4b5"
+
+# Default values for dev / release modes
+DEV_RATE_LIMIT_DEFAULT := "false"
+DEV_RUST_LOG_DEFAULT   := "debug"
+REL_RATE_LIMIT_DEFAULT := "true"
+REL_RUST_LOG_DEFAULT   := "warn"
+
+# Values that can also be overridden via .env
+APP_RATE_LIMITING__ENABLED := "true"
+RUST_LOG := "warn"
+
+# ── 🚀 Start service (release / dev) ───────────────────────────────
+# Release: rate limiting ON, log = warn by default
+start rate="true" log="warn":
+    @echo "🟢 Starting service in release mode..."
+    RUST_LOG={{log}} APP_RATE_LIMITING__ENABLED={{rate}} cargo run --release
+
+# Dev: rate limiting OFF, log = debug by default
+start-dev rate="false" log="debug":
+    @echo "🟡 Starting service in dev mode..."
+    RUST_LOG={{log}} APP_RATE_LIMITING__ENABLED={{rate}} cargo run
+
+prepare-shorten-data:
+	#!{{shebang}}
+	nu ./scripts/prepare_shorten_data.nu
+
+prepare-redirect-data:
+	#!{{shebang}}
+	nu ./scripts/prepare_redirect_data.nu
+
+# ── 📊 Performance Tests - Shorten ────────────────────────────────
+perf-shorten:
+	#!{{shebang}}
+	use '{{justfile_directory()}}/scripts/prepare_shorten_data.nu'
+
+	let ts = (date now | format date "%Y%m%d_%H%M%S")
+	let file = prepare_shorten_data
+	let name = "shorten"
+	let prefix = $"./reports/($ts)_($name)"
+	mkdir reports | ignore
+
+	print $"󱐋 Running shorten test → reports in ($prefix)_*"
+	with-env {
+		BASE: "{{BASE}}"
+		API_KEY: "{{API_KEY}}"
+		URL_FILE: $file
+		REPORT_PREFIX: $prefix
+		K6_WEB_DASHBOARD: "true"
+		K6_WEB_DASHBOARD_PERIOD: "3s"
+		K6_WEB_DASHBOARD_EXPORT: $"($prefix)_dashboard.html"
+	} { ^k6 run ./tests/perf/shorten.js }
+	print "report saved in:"
+	print $"\t\t($prefix)_summary.txt"
+	print $"\t\t($prefix)_summary.json"
+	print $"\t\t($prefix)_dashboard.html"
+	open $"($prefix)_summary.txt"
+
+# ── 🔁 Performance Tests - Redirect ───────────────────────────────
+perf-redirect:
+	#!{{shebang}}
+	use '{{justfile_directory()}}/scripts/prepare_redirect_data.nu'
+
+	let ts = (date now | format date "%Y%m%d_%H%M%S")
+	let file = prepare_redirect_data
+
+	let name = "redirect"
+	let prefix = $"./reports/($ts)_($name)"
+	mkdir reports | ignore
+	print $"󱐋 Running redirect test → reports in ($prefix)"
+
+	with-env {
+		BASE: "{{BASE}}"
+		API_KEY: "{{API_KEY}}"
+		REPORT_PREFIX: $prefix
+		URL_FILE: $file
+		K6_WEB_DASHBOARD: "true"
+		K6_WEB_DASHBOARD_PERIOD: "3s"
+		K6_WEB_DASHBOARD_EXPORT: $"($prefix)_dashboard.html"
+	} { ^k6 run ./tests/perf/redirect.js }
+	open $"($prefix)_summary.txt"

--- a/scripts/gen_repeat_url.nu
+++ b/scripts/gen_repeat_url.nu
@@ -1,0 +1,59 @@
+use ./helpers.nu [human_count]
+
+# Scenario 1: Duplicate some entries in the existing URL list by a percentage (to create duplicates)
+def main [
+  --pct: int = 25,                                       # Required: percentage of duplicates to add, between 0..100, e.g. 25
+  --input_path  (-i): path = "./scripts/data/urls.txt",
+  --output_path (-o): path = "./tests/perf/data/",
+  --field       (-f): string = "url"                     # Reserved parameter (same as original), not used here
+  --limit       (-l): int = 100_000                      # Max number of lines to read, default: 100K
+  --start       (-s): int = 0                            # New: Start from this line (0-based)
+] {
+  # Validate parameters
+  if $pct < 0 or $pct > 100 {
+    error make { msg: "pct must be between 0 and 100" }
+  }
+  if $limit <= 0 {
+    error make { msg: "limit must be greater than 0" }
+  }
+
+  # Read the original list, trim whitespace, skip empty lines, and apply line limits (✂️)
+  let orig_list = (
+    open $input_path
+    | lines
+    | skip $start
+    | take $limit
+    | each {|x| $x | str trim }
+    | where {|x| $x != "" }
+  )
+
+  let orig_count = ($orig_list | length)
+  if $orig_count == 0 {
+    error make { msg: $"Input file is empty or no data read from ($input_path)" }
+  }
+
+  # Calculate the number of duplicates to add
+  let pct_decimal = ($pct | into float | $in / 100)
+  let add_count = (if $pct_decimal == 1 {
+      error make { msg: "pct cannot be 100 — infinite duplicates would be required 😅" }
+  } else {
+      ($orig_count * $pct_decimal) / (1 - $pct_decimal)
+  } | math round)
+
+  let total_count = $orig_count + $add_count
+
+  # Sample and shuffle
+  let dup_list = (if $add_count > 0 { $orig_list | shuffle | take $add_count } else { [] })
+  let mixed = ($orig_list | append $dup_list) | shuffle
+
+  # Save output file
+  mkdir $output_path
+  let size_tag = (human_count $orig_count)
+  let name = $"url_repeat_($pct)%_($size_tag).txt"
+  $mixed | save -f ($output_path | path join ($name))
+
+  # Print summary
+  let eff_pct = (if $total_count == 0 { 0 } else { ($add_count * 100) // $total_count })
+  print $"✅ Generation completed: ($output_path | path join ($name))"
+  print $"Lines read: ($orig_count), Original count: ($orig_count), Duplicates added: ($add_count), Total: ($total_count), Duplicate ratio: ($eff_pct)%"
+}

--- a/scripts/gen_short_id.nu
+++ b/scripts/gen_short_id.nu
@@ -1,0 +1,52 @@
+use ./helpers.nu [gen_custom_id human_count timestamp]
+
+def main [
+  --pct: int = 25,                                                # % of new IDs to generate (0–100)
+  --input_path  (-i): path = "./scripts/data/urls.csv",           # Input CSV path (must have 'id')
+  --config_path (-c): path = "./configuration/generator.yml",     # Generator config (length, alphabet)
+  --output_path (-o): path = "./tests/perf/data/"                 # Output folder
+] {
+  # Validate parameters
+  if $pct < 0 or $pct > 100 {
+    error make { msg: "pct must be between 0 and 100" }
+  }
+
+  # Load config & original data
+  let cfg = open $config_path
+  let orig_list = (open $input_path | get id)
+  let orig_count = ($orig_list | length)
+  if $orig_count == 0 {
+    error make { msg: $"No 'id' field found or file is empty: ($input_path)" }
+  }
+
+  # Calculate number to generate
+  let pct_decimal = ($pct | into float | $in / 100)
+  let add_count = (if $pct_decimal == 1 {
+      error make { msg: "pct cannot be 100 😅" }
+  } else {
+      ($orig_count * $pct_decimal) / (1 - $pct_decimal)
+  } | math round)
+
+  let total_count = $orig_count + $add_count
+
+  # Generate IDs
+  let indices = (if $add_count > 0 { 1..$add_count } else { [] })
+  let gen_list = (
+    $indices
+    | each { gen_custom_id $cfg.shortener.length $cfg.shortener.alphabet }
+  )
+
+  # Merge & shuffle
+  let combined = ($orig_list | append $gen_list) | shuffle
+
+  # Save output
+  mkdir $output_path
+  let size_tag = (human_count $orig_count)
+  let name = $"db_code_extra_($pct)%_($size_tag)_(timestamp)"
+  $combined | save -f ($output_path | path join ($name + ".txt"))
+
+  # Summary
+  let eff_pct = (if $total_count == 0 { 0 } else { ($add_count * 100) // $total_count })
+  print $"✅ Generated: ($output_path | path join ($name + '.txt'))"
+  print $"Original: ($orig_count), New: ($add_count), Total: ($total_count), Ratio: ($eff_pct)%"
+}

--- a/scripts/get_ulr_data_from_db.nu
+++ b/scripts/get_ulr_data_from_db.nu
@@ -1,0 +1,169 @@
+# Dependencies: psql / sqlite3; in container mode, ensure the client exists inside the container.
+
+def main [
+  --db_type: string     # sqlite | pg
+  --db_url: string      # sqlite: file path or sqlite://... ; pg: postgres://...
+  --db_yml: path        = "./configuration/base.yml"   # Optional YAML; CLI flags take precedence
+  --output (-o): path        = "./scripts/data"             # Export directory
+  --tables: string      = "urls"                       # Tables to export, comma-separated (supports schema.table)
+  --container: string   = ""                           # Docker container ID/Name; empty = run on host
+] {
+  # Read YAML if present; CLI has priority
+  let cfg = if ($db_yml | path exists) { open $db_yml } else { {} }
+
+  let eff_type = (
+    [ $db_type ($cfg.database.type? | default null) ]
+    | compact | first | default "" | str downcase
+  )
+  let eff_url = (
+    [ $db_url ($cfg.database.url? | default null) ]
+    | compact | first | default ""
+  )
+
+  if $eff_type == "" { error make { msg: "Provide --db_type or set database.type in YAML" } }
+  if $eff_url  == "" { error make { msg: "Provide --db_url or set database.url in YAML" } }
+
+  # mkdir $output
+
+  # Normalize --tables (commas/whitespace supported)
+  let tbls = if ($tables | str length) == 0 {
+    []
+  } else {
+    $tables
+    | str replace -a "," " "
+    | split row " "
+    | each { |t| $t | str trim }
+    | where { |t| $t != "" }
+  }
+
+  match $eff_type {
+    "sqlite" => { export-sqlite $eff_url $output $container $tbls }
+    "pg" | "postgres" | "postgresql" => { export-pg $eff_url $output $container $tbls }
+    _ => { error make { msg: $"Unsupported db_type: ($eff_type)" } }
+  }
+}
+
+# ---------- Helpers ----------
+def quote_ident [name: string] {
+  # Escape inner double quotes for identifiers
+  let inner = ($name | str replace --all '"' '""')
+  $"\"($inner)\""
+}
+
+def sanitize_filename [s?: string] {
+  let v = if $s == null { $in } else { $s }
+  $v
+  | into string
+  | str replace --all "." "__"
+  | str replace --all "/" "_"
+  | str replace --all "\\" "_"
+}
+
+def escape_single_quote [s: string] {
+  # For single-quoted literals in \copy TO 'path'
+  $s | str replace --all "'" "''"
+}
+
+# ---------- SQLite ----------
+def export-sqlite [
+  url_or_path: string
+  outdir: path
+  container: string
+  tables: list<any>
+] {
+  let db_path = if ($url_or_path | str starts-with "sqlite://") {
+    $url_or_path | str replace -a "sqlite://" ""
+  } else { $url_or_path }
+
+  let use_dk = ($container | default "" | str length) > 0
+
+  # Decide tables to export
+  let target_tables = if ($tables | length) > 0 {
+    $tables
+  } else {
+    let list_sql = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;"
+    if $use_dk {
+      ^docker exec $container sqlite3 $db_path $list_sql | lines
+    } else {
+      ^sqlite3 $db_path $list_sql | lines
+    }
+  }
+
+  if ($target_tables | length) == 0 {
+    print "(SQLite) No exportable tables found"
+    return
+  }
+
+  for t in $target_tables {
+    let tname = ($t | into string)
+    let fname = (sanitize_filename $tname) + ".csv"
+    # let outfile = ($outdir | path join $fname)
+    let q = $"SELECT * FROM \"($tname)\";"
+
+    if ($container | is-empty) {
+      ^sqlite3 -header -csv $db_path $q | save --raw --force $outdir
+    } else {
+      ^docker exec $container sqlite3 -header -csv $db_path $q | save --raw --force $outdir
+    }
+    print $"[SQLite] Exported table: ($tname) -> ($outdir)"
+  }
+}
+
+# ---------- Postgres ----------
+def export-pg [
+  pg_url: string
+  outdir: path
+  container: string
+  tables: list<any>
+] {
+  let use_dk = ($container | default "" | str length) > 0
+  print $outdir
+
+  # Decide tables to export (schema optional)
+  let target_tables = if ($tables | length) > 0 {
+    $tables
+  } else {
+    # If not specified, export all non-system tables
+    let list_sql = "SELECT schemaname||'.'||tablename FROM pg_catalog.pg_tables WHERE schemaname NOT IN ('pg_catalog','information_schema') ORDER BY schemaname, tablename;"
+    if $use_dk {
+      ^docker exec $container psql $pg_url -At -c $list_sql | lines
+    } else {
+      ^psql $pg_url -At -c $list_sql | lines
+    }
+  }
+
+  if ($target_tables | length) == 0 {
+    print "(Postgres) No exportable tables found"
+    return
+  }
+
+  for raw in $target_tables {
+    let st = ($raw | into string | str trim)
+
+    # Parse schema.table or table
+    let parts = ($st | split row "." | take 2)
+    let schema = if ($parts | length) == 2 { ($parts | get 0) } else { "" }
+    let table  = if ($parts | length) == 2 { ($parts | get 1) } else { ($parts | get 0) }
+
+    let qschema = if ($schema | str length) > 0 { (quote_ident $schema) } else { "" }
+    let qtable  = (quote_ident $table)
+    let obj     = if ($qschema | str length) > 0 { $"($qschema).($qtable)" } else { $qtable }
+
+    let fname = ((if ($schema | str length) > 0 { $"($schema)__($table)" } else { $table }) | sanitize_filename) + ".csv"
+    # let outfile = ($outdir | path join $fname)
+    # let outfile_abs = ($outfile | path expand)
+    # let outfile_sql_lit = (escape_single_quote $outfile_abs)
+    let cmd = $"COPY ($obj) TO STDOUT WITH \(FORMAT CSV, HEADER\)"
+
+    if not $use_dk {
+      # Host: stream CSV to file; \copy writes client-side
+      print $"Running: psql <url> -c: ($cmd) -> ($outdir)"
+      ^psql ($pg_url) -c ($cmd) | save --raw --force ($outdir)
+    } else {
+      # Container: stream CSV via STDOUT back to host
+      ^docker exec $container psql $pg_url -c $cmd | save --raw --force $outdir
+    }
+
+    print $"[Postgres] Exported table: ($table) -> ($outdir)"
+  }
+}

--- a/scripts/get_urls.nu
+++ b/scripts/get_urls.nu
@@ -1,0 +1,13 @@
+def main [
+    --output_path (-o): path = "urls.txt" # output urls.txt path location
+] {
+    curl -L https://tranco-list.eu/download/daily/tranco_4N3XX-1m.csv.zip -o top-1m.csv.zip
+
+    let filename = "top-1m.csv"
+
+    # # 2) Unzip to a single CSV file
+    unzip -p "./top-1m.csv.zip" | save -f $filename
+
+    open --raw $filename | $"id,url(char nl)($in)" |
+    from csv | get url | par-each { $"https://($in)" } | save --force $output_path
+};

--- a/scripts/helpers.nu
+++ b/scripts/helpers.nu
@@ -1,0 +1,27 @@
+# Convert numbers to short labels: 999 -> "999", 10_000 -> "10K", 2_300_000 -> "2.3M", 4_100_000_000 -> "4.1B"
+export def human_count [n: int] {
+  if $n < 1000 {
+    $n | into string
+  } else if $n < 1_000_000 {
+    ((($n | into float) / 1000) | math round | into int | into string) + "K"
+  } else if $n < 1_000_000_000 {
+    ((($n | into float) / 1_000_000) | math round | into int | into string) + "M"
+  } else {
+    ((($n | into float) / 1_000_000_000) | math round | into int | into string) + "B"
+  }
+}
+
+# Generate a random custom short ID with given length and charset
+export def gen_custom_id [length: int, charset: string] {
+  let chars = $charset | split chars
+  let n = ($chars | length)
+  (1..$length | each { $chars | get (random int ..<$n) }) | str join
+}
+
+# Generate a timestamp suffix, e.g. _20251011123045
+export def timestamp [] { date now | format date "%Y%m%d%H%M%S" }
+
+
+export def exists_and_nonempty [p : path]: nothing -> bool {
+  try { (ls ($p | into glob) | get size.0 | into int) > 0 } catch { false }
+}

--- a/scripts/prepare_redirect_data.nu
+++ b/scripts/prepare_redirect_data.nu
@@ -1,0 +1,48 @@
+use helpers.nu [timestamp exists_and_nonempty]
+
+
+def try_get [file: path]: nothing -> path {
+    if not (exists_and_nonempty $file) {
+        return ""
+    }
+        
+    glob $file | last
+}
+
+def ensure_urls_in_db_csv []: nothing -> path {
+    let ts = timestamp
+    mut csv = try_get ./scripts/data/urls_in_db*.csv
+
+    if ($csv == "") {
+        print "→ generating urls_in_db_*.csv via get_ulr_data_from_db.nu"
+        mkdir "./scripts/data" | ignore
+        let out = $"./scripts/data/urls_in_db_($ts).csv"
+        nu ./scripts/get_ulr_data_from_db.nu -o $out
+
+        $csv = $out
+    }
+
+    $csv
+}
+
+def generate_db_extra [csv: string]: nothing -> path {
+    mkdir "./tests/perf/data" | ignore
+    nu ./scripts/gen_short_id.nu -i $csv
+    let out = (glob "tests/perf/data/db_code_extra_*.txt" | last)
+    if $out == null { return "" } else { $out }
+}
+
+
+export def main []: nothing -> path {
+    mut file = (try_get "tests/perf/data/db_code_extra_*.txt")
+
+    if ($file == "") {
+        let csv = ensure_urls_in_db_csv
+        print "→ generating db_code_extra_* via gen_short_id.nu"
+        $file = generate_db_extra $csv
+    } else if not (exists_and_nonempty $file) {
+        error make { msg: "Failed to prepare db_code_extra_* file." }
+    }
+
+    $file
+}

--- a/scripts/prepare_shorten_data.nu
+++ b/scripts/prepare_shorten_data.nu
@@ -1,0 +1,39 @@
+use helpers.nu [timestamp exists_and_nonempty]
+
+def ensure_urls_txt []: nothing -> string {
+    let out = "./scripts/data/urls.txt"
+    if not (exists_and_nonempty $out) {
+        print "→ generating ./scripts/data/urls.txt via get_urls.nu"
+        mkdir "./scripts/data" | ignore
+        nu ./scripts/get_urls.nu -o $out
+    }
+    $out
+}
+
+def latest_url_repeat []: nothing -> path {
+    let m = (glob "./tests/perf/data/url_repeat_*" | if ($in | is-empty) { "" } else { last })
+
+    $m
+}
+
+def generate_url_repeat []: nothing -> string {
+    mkdir "./tests/perf/data" | ignore
+    nu ./scripts/gen_repeat_url.nu
+}
+
+export def main []: nothing -> path {
+    mut file = latest_url_repeat
+
+    if  not (exists_and_nonempty $file) {
+        ensure_urls_txt
+        print "→ generating url_repeat_* via gen_*_url.nu"
+        generate_url_repeat
+        $file = latest_url_repeat
+    }
+    if ($file == "" or not (exists_and_nonempty $file)) {
+        error make { msg: "Failed to prepare url_repeat_* file." }
+    }
+
+    $file
+}
+

--- a/tests/perf/redirect.js
+++ b/tests/perf/redirect.js
@@ -1,0 +1,122 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { SharedArray } from 'k6/data';
+import { scenario } from 'k6/execution';
+import { Counter, Rate } from 'k6/metrics';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.4/index.js';
+
+// Report dir (env overrideable). Ensure trailing slash for safe path joins.
+const REPORT_PREFIX = __ENV.REPORT_PREFIX || './reports/redirect'; 
+const URL_FILE = __ENV.URL_FILE
+
+// ===== Data load (once) =====
+// Use SharedArray to ensure large file is read once
+const ids = new SharedArray("ids", () =>
+  open(URL_FILE)
+    .trim()
+    .split("\n")
+);
+
+// ===== Custom metrics =====
+const status308 = new Counter('status_308');
+const status404 = new Counter('status_404');
+const statusOther = new Counter('status_other');
+const rate404   = new Rate('rate_404'); // 404 ratio
+
+// ===== Scenario & thresholds (60s) =====
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    loop_test: {
+      executor: 'constant-vus',
+      vus: 750,          // concurrency
+      duration: '60s',   // fixed 60s
+    },
+  },
+  thresholds: {
+    rate_404: ['rate>=0.23', 'rate<=0.27'], // expect ~25%
+    http_req_duration: ['p(99)<300'],
+  },
+};
+
+// ===== Main loop (runs for 60s) =====
+export default function () {
+  // Round-robin selection to avoid out-of-bounds
+  const idx = Number(scenario.iterationInTest % ids.length);
+  const id = ids[idx];
+  const url = `http://127.0.0.1:8000/${id}`;
+
+  const res = http.get(url, { redirects: 0 });
+
+  const is308 = res.status === 308;
+  const is404 = res.status === 404;
+
+  // Counters
+  if (is308) status308.add(1);
+  else if (is404) status404.add(1);
+  else statusOther.add(1);
+
+  // 404 ratio
+  rate404.add(is404);
+
+  // Assertions
+  check(res, {
+    'status is 308 or 404': (r) => r.status === 308 || r.status === 404,
+  });
+
+  // Optional light throttling to protect local host
+  // sleep(0.001);
+}
+
+// ===== Summary (includes totals & avg RPS) =====
+export function handleSummary(data) {
+  const m = data.metrics;
+
+  const c308   = m['status_308']?.values?.count || 0;
+  const c404   = m['status_404']?.values?.count || 0;
+  const cOther = m['status_other']?.values?.count || 0;
+  const total  = c308 + c404 + cOther;
+
+  const p404 = total ? (c404 / total) * 100 : 0;
+  const p308 = total ? (c308 / total) * 100 : 0;
+
+  // Use runtime duration (ms) to compute avg RPS
+  const durMs    = data?.state?.testRunDurationMs || 60000;
+  const durSec   = durMs / 1000;
+  const httpReqs = m['http_reqs']?.values?.count || total; // completed HTTP requests
+  const avgRps   = durSec > 0 ? (httpReqs / durSec) : 0;
+
+  const summaryText =
+    `Status breakdown\n` +
+    `----------------\n` +
+    `308: ${c308} (${p308.toFixed(2)}%)\n` +
+    `404: ${c404} (${p404.toFixed(2)}%)\n` +
+    `Other: ${cOther}\n` +
+    `Total: ${total}\n\n` +
+    `Throughput\n` +
+    `----------\n` +
+    `http_reqs (completed): ${httpReqs}\n` +
+    `avg_rps: ${avgRps.toFixed(2)} req/s (duration: ${durSec.toFixed(2)}s)\n`;
+
+  return {
+    // human-readable k6 summary
+    [`${REPORT_PREFIX}_summary.txt`]: textSummary(data, { indent: ' ', enableColors: true }),
+    // raw k6 JSON (full)
+    [`${REPORT_PREFIX}_summary.json`]: JSON.stringify(data),
+    // concise status breakdown
+    [`${REPORT_PREFIX}_status_breakdown.txt`]: summaryText,
+    [`${REPORT_PREFIX}_status_breakdown.json`]: JSON.stringify(
+      {
+        count_308: c308,
+        count_404: c404,
+        count_other: cOther,
+        total,
+        http_reqs: httpReqs,
+        avg_rps: Number(avgRps.toFixed(4)),
+        duration_seconds: Number(durSec.toFixed(3)),
+      },
+      null,
+      2
+    ),
+  };
+}

--- a/tests/perf/shorten.js
+++ b/tests/perf/shorten.js
@@ -1,0 +1,63 @@
+import http from "k6/http";
+import { check } from "k6";
+import { SharedArray } from "k6/data";
+import { scenario } from "k6/execution";
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.4/index.js';
+
+// ── Environment variables ────────────────────────────────────────
+// Convention: only use REPORT_PREFIX for naming all output artifacts
+const BASE_URL = __ENV.BASE_URL || 'http://127.0.0.1:8000';
+const API_KEY = __ENV.API_KEY;
+const REPORT_PREFIX = __ENV.REPORT_PREFIX || './reports/shorten'; // fallback to avoid errors
+const URL_FILE = __ENV.URL_FILE
+
+// ===== Data load (once) =====
+// Use SharedArray to ensure large file is read once
+const urls = new SharedArray("urls", () =>
+  open(URL_FILE)
+    .trim()
+    .split("\n")
+);
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    once_per_url: {
+      executor: 'shared-iterations',
+      vus: 300,
+      iterations: urls.length,
+      maxDuration: '10m',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+    http_req_duration: ['p(95)<500'],
+  },
+};
+
+if (!API_KEY) {
+  throw new Error('API_KEY is not set (use -e API_KEY=...)');
+}
+
+export default function () {
+  const idx = scenario.iterationInTest;
+  if (idx >= urls.length) return;
+
+  const payload = urls[idx];
+  const headers = {
+    'Content-Type': 'text/plain',
+    'x-api-key': API_KEY,
+  };
+
+  const res = http.post(`${BASE_URL}/api/shorten`, payload, { headers });
+  check(res, { 'status is 200': r => r.status === 200 });
+}
+
+// ── Unified summary output ──────────────────────────────────────
+export function handleSummary(data) {
+  return {
+    // Text & JSON summaries under REPORT_PREFIX
+    [`${REPORT_PREFIX}_summary.txt`]: textSummary(data, { indent: ' ', enableColors: true }),
+    [`${REPORT_PREFIX}_summary.json`]: JSON.stringify(data),
+  };
+}


### PR DESCRIPTION
## Description  
Added a performance test suite using `k6`, along with data generation scripts in Nushell.  
Included a `justfile` to simplify workflows like test execution and data preparation.

All scripts and tests run natively on **Windows, Linux, and macOS** with **no shell-specific dependencies** — only `nushell` and `just` are required.


## Type of Change  
- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [x] Performance improvement  
- [ ] Other (please describe)

## Testing  
- [x] Tests pass locally  
- [x] New tests added for new functionality  
- [x] Manual testing completed  

## Checklist  
- [x] Code follows project style guidelines  
- [x] Self-review completed  
- [x] Code is commented where necessary  
- [ ] Documentation updated  
- [x] No merge conflicts  


## Details  

- Introduced `justfile` to orchestrate performance workflows via `just` and `nushell`  
- Load test scripts:  
  - `tests/perf/shorten.js`: POST tests for shorten API  
  - `tests/perf/redirect.js`: GET tests with status breakdown and throughput summary  
- Data preparation scripts:  
  - `gen_repeat_url.nu`: generate realistic duplicated URL lists  
  - `gen_short_id.nu`: generate short IDs based on config  
  - `get_ulr_data_from_db.nu`: export URLs from SQLite or PostgreSQL  
  - `get_urls.nu`: fetch Tranco top-1M domain list  
  - `prepare_shorten_data.nu` & `prepare_redirect_data.nu`: end-to-end prep pipelines  
- Utilities: `helpers.nu` for ID generation, file validation, and timestamping  
- Output: structured reports saved to `./reports/`, including `.txt`, `.json`, and web dashboards